### PR TITLE
Add sound attribution for Zapsplat.com to README and in Game

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 It's just vanilla html, css, js
 
 The game can be accessed [here](https://datadaveshin.github.io/asteroids_web/)
+
+## License
+This project is licensed under the MIT License. See the [LICENSE](https://github.com/datadaveshin/asteroids_web/blob/main/LICENSE.md) file for details.
+
+## Attribution for Third-Party Assets
+This project uses sound effects provided by [Zapsplat.com](https://www.zapsplat.com) under the [CC0 1.0 Universal License](https://creativecommons.org/publicdomain/zero/1.0/).
+
+### Attribution:
+> "Sound effects from Zapsplat.com, licensed under the [CC0 1.0 Universal License](https://creativecommons.org/publicdomain/zero/1.0/)."

--- a/game.js
+++ b/game.js
@@ -621,6 +621,9 @@ class Game {
             
             this.ctx.font = '16px "Press Start 2P", monospace';
             this.ctx.fillText('Arrow Keys to Move    Space to Shoot', this.canvas.width / 2, this.canvas.height * 3/4);
+
+            this.ctx.font = '12px "Press Start 2P", monospace';
+            this.ctx.fillText('Sound effects from Zapsplat.com', this.canvas.width / 2, this.canvas.height - 10);
             this.ctx.restore();
             
         } else if (this.gameState === 'playing') {
@@ -645,6 +648,9 @@ class Game {
             this.ctx.fillText(`High Score: ${this.highScore}`, this.canvas.width / 2, this.canvas.height / 2 + 40);
             
             this.ctx.fillText('Press Enter to Restart', this.canvas.width / 2, this.canvas.height * 3/4);
+
+            this.ctx.font = '12px "Press Start 2P", monospace';
+            this.ctx.fillText('Sound effects from Zapsplat.com', this.canvas.width / 2, this.canvas.height - 10);
             this.ctx.restore();
         }
     }


### PR DESCRIPTION
This PR adds the required attribution for sound effects sourced from Zapsplat.com. The following changes were made:

- Added sound attribution text in the README file.
- Included sound attribution in the game.

Fixes #7 
